### PR TITLE
Fix typo npm → pip in python-compatibility.md

### DIFF
--- a/doc_source/python-compatibility.md
+++ b/doc_source/python-compatibility.md
@@ -9,7 +9,7 @@ For more information, see the following on the Python Packaging Authority's GitH
 
 ## pip command support<a name="pip-command-support"></a>
 
-The following sections summarize the npm commands that are supported, by CodeArtifact repositories, in addition to specific commands that are not supported\.
+The following sections summarize the pip commands that are supported, by CodeArtifact repositories, in addition to specific commands that are not supported\.
 
 **Topics**
 + [Supported commands that interact with a repository](#supported-pip-commands-that-interact-with-a-repository)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fixing a typo. A page about Python mentions npm.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
