### PR TITLE
Replace new customer managed policy with identical AWS managed policy

### DIFF
--- a/doc_source/get-set-up-provision-user.md
+++ b/doc_source/get-set-up-provision-user.md
@@ -6,32 +6,8 @@ Follow these instructions to prepare an IAM user to use CodeArtifact\.
 
 1. Create an IAM user, or use one that is associated with your AWS account\. For more information, see [Creating an IAM User](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_SettingUpUser.html#Using_CreateUser_console) and [Overview of AWS IAM Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/PoliciesOverview.html) in the *IAM User Guide*\.
 
-1. Grant the IAM user access to CodeArtifact using the following policy\.
+1. Grant the IAM user access to CodeArtifact using the `AWSCodeArtifactAdminAccess` AWS managed policy\.
 
-   ```
-   {
-   "Version": "2012-10-17",
-   "Statement": [
-      {
-        "Effect": "Allow",
-        "Action": [
-             "codeartifact:*"
-        ],
-        "Resource": "*"
-      },
-      {       
-        "Effect": "Allow",
-        "Action": "sts:GetServiceBearerToken",
-        "Resource": "*",
-        "Condition": {
-            "StringEquals": {
-                "sts:AWSServiceName": "codeartifact.amazonaws.com"
-            }
-         }
-       }
-   ]
-   }
-   ```
 **Important**  
 This policy grants access to all CodeArtifact APIs\. We recommend that you always use the minimum permissions required to accomplish your task\. For more information, see [IAM Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html) in the *IAM User Guide*\. 
 


### PR DESCRIPTION
**Description of changes**
The reader is advised to create a new policy to grant access to CodeArtifact. However, the policy is identical to an existing AWS managed policy (**AWSCodeArtifactAdminAccess**) and so the reader can just use the existing policy instead of creating a new one.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
