### PR TITLE
Update tokens-authentication.md

### DIFF
--- a/doc_source/tokens-authentication.md
+++ b/doc_source/tokens-authentication.md
@@ -21,7 +21,7 @@ The following table describes the parameters for the `login` command\.
 
 | Parameter | Required | Description | 
 | --- | --- | --- | 
-| `--tool` | Yes | The package manager to authenticate to\. Possible values are `maven`, `npm`, and `pip`\. | 
+| `--tool` | Yes | The package manager to authenticate to\. Possible values are `twine`, `npm`, and `pip`\. | 
 | `--domain` | Yes | The domain name that the repository belongs to\. | 
 | `--domain-owner` | No | The ID of the owner of the domain\. This parameter is required if accessing a domain that is owned by an AWS account that you are not authenticated to\. For more information, see [Cross\-account domains](domain-overview.md#domain-overview-cross-account)\. | 
 | `--repository` | Yes | The name of the repository to authenticate to\. | 


### PR DESCRIPTION
removes incorrect mentioning of 'maven' from list of allowed values as parameter for 'aws codeartifact login --tool' and replaces it with correct value 'twine'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
