### PR TITLE
Third way to use aws codeartifact in build.gradle

### DIFF
--- a/doc_source/maven-gradle.md
+++ b/doc_source/maven-gradle.md
@@ -203,3 +203,25 @@ Use this method if you do not want to modify your `gradle.properties` file\.
    ```
    echo "codeartifactToken=$CODEARTIFACT_AUTH_TOKEN" > file
    ```
+  
+**Method 3: Execute `aws` as an inline script**
+
+Use this method if you want the gradle script to fetch a new token on each run\.
+
+1. Update your `build.gradle` file with the following snippet:
+
+   ```
+    def awsToken = "aws codeartifact get-authorization-token --domain my-domain --domain-owner domain-owner-id --query authorizationToken --output text --profile profile-name".execute().text
+   repositories {
+   
+       maven {
+                url 'https://my-domain-domain-owner-id.d.codeartifact.region.amazonaws.com/maven/my-repo/'
+                credentials {
+                    username "aws"
+                    password awsToken
+                }
+       }
+   }
+   ```
+   
+This way the token is never stored on the local file system.


### PR DESCRIPTION
Suggested third method to execute `aws codeartifact get-authorization-token` on each run, never storing it on the local filesystem.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
