### PR TITLE
Add nuget to the local cache folder examples

### DIFF
--- a/doc_source/dependency-caching.md
+++ b/doc_source/dependency-caching.md
@@ -21,3 +21,4 @@ For other tools, use the cache folders shown in this table\.
 |   ** `gradle` **   |   `/root/.gradle/caches/**/*`   | 
 |   ** `pip` **   |   `/root/.cache/pip/**/*`   | 
 |   ** `npm` **   |   `/root/.npm/**/*`   | 
+|   ** `nuget` **   |   `/root/.nuget/**/*`   | 


### PR DESCRIPTION
*Description of changes:*
Add .NET's `nuget` package manager cache directory to the list of tool examples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
