### PR TITLE
Add the cache dir example for the yarn classic

### DIFF
--- a/doc_source/dependency-caching.md
+++ b/doc_source/dependency-caching.md
@@ -22,3 +22,4 @@ For other tools, use the cache folders shown in this table\.
 |   ** `pip` **   |   `/root/.cache/pip/**/*`   | 
 |   ** `npm` **   |   `/root/.npm/**/*`   | 
 |   ** `nuget` **   |   `/root/.nuget/**/*`   | 
+|   ** `yarn` (classic) |   `/root/.cache/yarn/**/*`   | 


### PR DESCRIPTION
*Issue #, if available:*

There is no issue I made for.

The current [Dependency Caching page](https://docs.aws.amazon.com/codeartifact/latest/ug/dependency-caching.html) does not explain how to configure the codebuild cache for Yarn.

*Description of changes:*

[Yarn v1 (Classic) uses `~/.cache/yarn` as its dependency cache dir for linux environment](https://github.com/yarnpkg/yarn/blob/3119382885ea373d3c13d6a846de743eca8c914b/src/util/user-dirs.js#L7), so .

Note that [Yarn v2+ (Berry) uses `./.yarn/cache` as its dependency cache dir](https://yarnpkg.com/configuration/yarnrc#cacheFolder), but I haven't tried to use it so this PR does not include changes for Yarn v2+.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. Thanks for checking this PR! 👋 