### PR TITLE
Fix missing d in pluginManagement maven repo definition

### DIFF
--- a/doc_source/maven-gradle.md
+++ b/doc_source/maven-gradle.md
@@ -191,7 +191,7 @@ The example shows the `gradle.properties` file located in `GRADLE_USER_HOME`\.
        repositories {
            maven {
                name 'my_repo'
-               url 'https://my_domain-111122223333.codeartifact.region.amazonaws.com/maven/my_repo/'
+               url 'https://my_domain-111122223333.d.codeartifact.region.amazonaws.com/maven/my_repo/'
                credentials {
                    username 'aws'
                    password "$codeartifactToken"
@@ -245,7 +245,7 @@ The example shows the `gradle.properties` file located in `GRADLE_USER_HOME`\.
        repositories {
            maven {
                name 'my_repo'
-               url 'https://my_domain-111122223333.codeartifact.region.amazonaws.com/maven/my_repo/'
+               url 'https://my_domain-111122223333.d.codeartifact.region.amazonaws.com/maven/my_repo/'
                credentials {
                    username 'aws'
                    password props.getProperty("codeartifactToken")
@@ -295,7 +295,7 @@ The example shows the `gradle.properties` file located in `GRADLE_USER_HOME`\.
        repositories {
            maven {
                name 'my_repo'
-               url 'https://my_domain-111122223333.codeartifact.region.amazonaws.com/maven/my_repo/'
+               url 'https://my_domain-111122223333.d.codeartifact.region.amazonaws.com/maven/my_repo/'
                credentials {
                    username 'aws'
                    password codeartifactToken


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding `.d` in pluginManagement maven repo definition.
I tried the CodeArtifact with Gradle today. For the url value in pluginManagement section, it still needs a `.d` otherwise Gradle can not find the plugin.  
I first tried the url without the `.d` but not working. Adding a `.d` solved my problem.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. Thanks for checking this PR! 👋
